### PR TITLE
GLUE-9670 Performance issue regarding expanding the resource relation in Glue API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "spryker/glue-application": "^1.0.0",
     "spryker/glue-application-extension": "^1.0.0",
     "spryker/kernel": "^3.22.0",
-    "spryker/product-resource-alias-storage": "^1.0.0",
+    "spryker/product-resource-alias-storage": "^1.1.0",
     "spryker/symfony": "^3.0.0"
   },
   "require-dev": {

--- a/src/Spryker/Glue/ProductsRestApi/Dependency/Client/ProductsRestApiToProductResourceAliasStorageClientBridge.php
+++ b/src/Spryker/Glue/ProductsRestApi/Dependency/Client/ProductsRestApiToProductResourceAliasStorageClientBridge.php
@@ -34,6 +34,17 @@ class ProductsRestApiToProductResourceAliasStorageClientBridge implements Produc
     }
 
     /**
+     * @param string $sku
+     * @param string $localeName
+     *
+     * @return array|null
+     */
+    public function findProductConcreteStorageDataBySku(string $sku, string $localeName): ?array
+    {
+        return $this->productResourceAliasStorageClient->getProductConcreteStorageDataBySku($sku, $localeName);
+    }
+
+    /**
      * @param string[] $skus
      * @param string $localeName
      *

--- a/src/Spryker/Glue/ProductsRestApi/Dependency/Client/ProductsRestApiToProductResourceAliasStorageClientBridge.php
+++ b/src/Spryker/Glue/ProductsRestApi/Dependency/Client/ProductsRestApiToProductResourceAliasStorageClientBridge.php
@@ -34,13 +34,13 @@ class ProductsRestApiToProductResourceAliasStorageClientBridge implements Produc
     }
 
     /**
-     * @param string $sku
+     * @param string[] $skus
      * @param string $localeName
      *
-     * @return array|null
+     * @return array
      */
-    public function findProductConcreteStorageDataBySku(string $sku, string $localeName): ?array
+    public function getBulkProductAbstractStorageData(array $skus, string $localeName): array
     {
-        return $this->productResourceAliasStorageClient->getProductConcreteStorageDataBySku($sku, $localeName);
+        return $this->productResourceAliasStorageClient->getBulkProductAbstractStorageData($skus, $localeName);
     }
 }

--- a/src/Spryker/Glue/ProductsRestApi/Dependency/Client/ProductsRestApiToProductResourceAliasStorageClientInterface.php
+++ b/src/Spryker/Glue/ProductsRestApi/Dependency/Client/ProductsRestApiToProductResourceAliasStorageClientInterface.php
@@ -18,6 +18,14 @@ interface ProductsRestApiToProductResourceAliasStorageClientInterface
     public function findProductAbstractStorageDataBySku(string $sku, string $localeName): ?array;
 
     /**
+     * @param string[] $skus
+     * @param string $localeName
+     *
+     * @return array
+     */
+    public function getBulkProductAbstractStorageData(array $skus, string $localeName): array;
+
+    /**
      * @param string $sku
      * @param string $localeName
      *

--- a/src/Spryker/Glue/ProductsRestApi/Processor/AbstractProducts/AbstractProductsReader.php
+++ b/src/Spryker/Glue/ProductsRestApi/Processor/AbstractProducts/AbstractProductsReader.php
@@ -142,6 +142,27 @@ class AbstractProductsReader implements AbstractProductsReaderInterface
     }
 
     /**
+     * @param array $abstractProductData
+     * @param \Spryker\Glue\GlueApplication\Rest\Request\Data\RestRequestInterface $restRequest
+     *
+     * @return \Spryker\Glue\GlueApplication\Rest\JsonApi\RestResourceInterface[]
+     */
+    protected function createRestResourcesFromBulkAbstractProductStorageData(array $abstractProductData, RestRequestInterface $restRequest): array
+    {
+        $restResources = [];
+
+        foreach ($abstractProductData as $abstractProductDataItem) {
+            $abstractProductRestResource = $this->abstractProductsResourceMapper
+                ->mapAbstractProductsResponseAttributesTransferToRestResponse($abstractProductData);
+
+            $restResources[$abstractProductDataItem[static::KEY_SKU]] =
+                $this->addConcreteProducts($abstractProductRestResource, $restRequest);
+        }
+
+        return $restResources;
+    }
+
+    /**
      * @param \Spryker\Glue\GlueApplication\Rest\JsonApi\RestResourceInterface $restResource
      * @param \Spryker\Glue\GlueApplication\Rest\Request\Data\RestRequestInterface $restRequest
      *
@@ -162,26 +183,5 @@ class AbstractProductsReader implements AbstractProductsReaderInterface
         }
 
         return $restResource;
-    }
-
-    /**
-     * @param array $abstractProductData
-     * @param \Spryker\Glue\GlueApplication\Rest\Request\Data\RestRequestInterface $restRequest
-     *
-     * @return \Spryker\Glue\GlueApplication\Rest\JsonApi\RestResourceInterface[]
-     */
-    protected function createRestResourcesFromBulkAbstractProductStorageData(array $abstractProductData, RestRequestInterface $restRequest): array
-    {
-        $restResources = [];
-
-        foreach ($abstractProductData as $abstractProductDataItem) {
-            $abstractProductRestResource = $this->abstractProductsResourceMapper
-                    ->mapAbstractProductsResponseAttributesTransferToRestResponse($abstractProductData);
-
-            $restResources[$abstractProductDataItem[static::KEY_SKU]] =
-                $this->addConcreteProducts($abstractProductRestResource, $restRequest);
-        }
-
-        return $restResources;
     }
 }

--- a/src/Spryker/Glue/ProductsRestApi/Processor/AbstractProducts/AbstractProductsReader.php
+++ b/src/Spryker/Glue/ProductsRestApi/Processor/AbstractProducts/AbstractProductsReader.php
@@ -126,7 +126,7 @@ class AbstractProductsReader implements AbstractProductsReaderInterface
      *
      * @return \Spryker\Glue\GlueApplication\Rest\JsonApi\RestResourceInterface[]
      */
-    public function getBulkProductAbstractBySkus(array $skus, RestRequestInterface $restRequest): array
+    public function getProductAbstractsBySkus(array $skus, RestRequestInterface $restRequest): array
     {
         $abstractProductData = $this->productResourceAliasStorageClient
             ->getBulkProductAbstractStorageData(

--- a/src/Spryker/Glue/ProductsRestApi/Processor/AbstractProducts/AbstractProductsReaderInterface.php
+++ b/src/Spryker/Glue/ProductsRestApi/Processor/AbstractProducts/AbstractProductsReaderInterface.php
@@ -21,6 +21,14 @@ interface AbstractProductsReaderInterface
     public function getProductAbstractStorageData(RestRequestInterface $restRequest): RestResponseInterface;
 
     /**
+     * @param string[] $skus
+     * @param \Spryker\Glue\GlueApplication\Rest\Request\Data\RestRequestInterface $restRequest
+     *
+     * @return \Spryker\Glue\GlueApplication\Rest\JsonApi\RestResourceInterface[]
+     */
+    public function getBulkProductAbstractBySkus(array $skus, RestRequestInterface $restRequest): array;
+
+    /**
      * @param string $sku
      * @param \Spryker\Glue\GlueApplication\Rest\Request\Data\RestRequestInterface $restRequest
      *

--- a/src/Spryker/Glue/ProductsRestApi/Processor/AbstractProducts/AbstractProductsReaderInterface.php
+++ b/src/Spryker/Glue/ProductsRestApi/Processor/AbstractProducts/AbstractProductsReaderInterface.php
@@ -26,7 +26,7 @@ interface AbstractProductsReaderInterface
      *
      * @return \Spryker\Glue\GlueApplication\Rest\JsonApi\RestResourceInterface[]
      */
-    public function getBulkProductAbstractBySkus(array $skus, RestRequestInterface $restRequest): array;
+    public function getProductAbstractsBySkus(array $skus, RestRequestInterface $restRequest): array;
 
     /**
      * @param string $sku

--- a/src/Spryker/Glue/ProductsRestApi/ProductsRestApiResource.php
+++ b/src/Spryker/Glue/ProductsRestApi/ProductsRestApiResource.php
@@ -34,6 +34,23 @@ class ProductsRestApiResource extends AbstractRestResource implements ProductsRe
     }
 
     /**
+     * {@inheritDoc}
+     *
+     * @api
+     *
+     * @param string[] $skus
+     * @param \Spryker\Glue\GlueApplication\Rest\Request\Data\RestRequestInterface $restRequest
+     *
+     * @return \Spryker\Glue\GlueApplication\Rest\JsonApi\RestResourceInterface[]
+     */
+    public function getBulkProductAbstractBySkus(array $skus, RestRequestInterface $restRequest): array
+    {
+        return $this->getFactory()
+            ->createAbstractProductsReader()
+            ->getBulkProductAbstractBySkus($skus, $restRequest);
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @api

--- a/src/Spryker/Glue/ProductsRestApi/ProductsRestApiResource.php
+++ b/src/Spryker/Glue/ProductsRestApi/ProductsRestApiResource.php
@@ -43,11 +43,11 @@ class ProductsRestApiResource extends AbstractRestResource implements ProductsRe
      *
      * @return \Spryker\Glue\GlueApplication\Rest\JsonApi\RestResourceInterface[]
      */
-    public function getBulkProductAbstractBySkus(array $skus, RestRequestInterface $restRequest): array
+    public function getProductAbstractsBySkus(array $skus, RestRequestInterface $restRequest): array
     {
         return $this->getFactory()
             ->createAbstractProductsReader()
-            ->getBulkProductAbstractBySkus($skus, $restRequest);
+            ->getProductAbstractsBySkus($skus, $restRequest);
     }
 
     /**

--- a/src/Spryker/Glue/ProductsRestApi/ProductsRestApiResourceInterface.php
+++ b/src/Spryker/Glue/ProductsRestApi/ProductsRestApiResourceInterface.php
@@ -27,6 +27,19 @@ interface ProductsRestApiResourceInterface
 
     /**
      * Specification:
+     *  - Retrieves multiple abstract product resource by sku.
+     *
+     * @api
+     *
+     * @param string[] $skus
+     * @param \Spryker\Glue\GlueApplication\Rest\Request\Data\RestRequestInterface $restRequest
+     *
+     * @return \Spryker\Glue\GlueApplication\Rest\JsonApi\RestResourceInterface[]
+     */
+    public function getBulkProductAbstractBySkus(array $skus, RestRequestInterface $restRequest): array;
+
+    /**
+     * Specification:
      *  - Retrieves concrete product resource by sku.
      *
      * @api

--- a/src/Spryker/Glue/ProductsRestApi/ProductsRestApiResourceInterface.php
+++ b/src/Spryker/Glue/ProductsRestApi/ProductsRestApiResourceInterface.php
@@ -27,7 +27,7 @@ interface ProductsRestApiResourceInterface
 
     /**
      * Specification:
-     *  - Retrieves multiple abstract product resource by sku.
+     *  - Retrieves multiple abstract product resources by sku.
      *
      * @api
      *

--- a/src/Spryker/Glue/ProductsRestApi/ProductsRestApiResourceInterface.php
+++ b/src/Spryker/Glue/ProductsRestApi/ProductsRestApiResourceInterface.php
@@ -27,7 +27,8 @@ interface ProductsRestApiResourceInterface
 
     /**
      * Specification:
-     *  - Retrieves multiple abstract product resources by sku.
+     * - Retrieves multiple abstract product resource by sku.
+     * - Returned collection of rest resources is indexed by product abstract sku.
      *
      * @api
      *
@@ -36,7 +37,7 @@ interface ProductsRestApiResourceInterface
      *
      * @return \Spryker\Glue\GlueApplication\Rest\JsonApi\RestResourceInterface[]
      */
-    public function getBulkProductAbstractBySkus(array $skus, RestRequestInterface $restRequest): array;
+    public function getProductAbstractsBySkus(array $skus, RestRequestInterface $restRequest): array;
 
     /**
      * Specification:


### PR DESCRIPTION
Branch: backport/glue-9670-catalog-seach-abstract-products-relationship-optimization
Ticket: https://spryker.atlassian.net/browse/GLUE-9670.
**Requires https://github.com/spryker/spryker/pull/6260 to be released first.**
Target version: 1.3.0

Release:
https://release.spryker.com/release/hotfix?pr=https%3A%2F%2Fgithub.com%2Fspryker%2Fproducts-rest-api%2Fpull%2F1

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ProductsRestApi               | minor                 |                       |

#### Release Notes

{skip}

-----------------------------------------

#### Module ProductsRestApi

##### Change log

Improvements

- Introduced `ProductsRestApiResource::getBulkProductAbstractBySkus()` that enables fetching miltiple `abstarct-products` resources by `sku`.
